### PR TITLE
Update .NET Core SDK version from 2.1.0 to 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ When an example requires packages that are not listed here, it will be added to 
 
 ## What's new in ASP.NET Core 2.1(2)
 
-  *Pre-requisite*: Make sure you download .NET Core SDK [2.1.0](https://www.microsoft.com/net/download/dotnet-core/2.1#sdk-2.1.400) otherwise below examples won't work.
+  *Pre-requisite*: Make sure you download .NET Core SDK [2.1.2](https://www.microsoft.com/net/download/dotnet-core/2.1#sdk-2.1.400) otherwise below examples won't work.
 
   **New code based idiom to start your host for ASP.NET Core 2.1**
 


### PR DESCRIPTION
SDK 2.1.400 is v2.1.2, while SDK 2.1.300 is v2.1.0.
Maybe it's just ok here to be just major.minor version;  2.1 for example, or if you agree with this change, then align it with current release.