### PR TITLE
Update Program.cs

### DIFF
--- a/projects/web-sockets/web-sockets-1/src/Program.cs
+++ b/projects/web-sockets/web-sockets-1/src/Program.cs
@@ -33,7 +33,7 @@ namespace PracticalAspNetCore
                 {
                     if (result.MessageType == WebSocketMessageType.Text)
                     {
-                        var clientRequest = Encoding.UTF8.GetString(receiveBuffer.Array, receiveBuffer.Offset, receiveBuffer.Count);
+                        var clientRequest = Encoding.UTF8.GetString(receiveBuffer.Array, receiveBuffer.Offset, result.Count);
 
                         var serverReply = Encoding.UTF8.GetBytes("Echo " + clientRequest);
                         var replyBuffer = new ArraySegment<byte>(serverReply);


### PR DESCRIPTION
For me, recieveBuffer.Count always returns 4096, which causes `clientRequest` string to be filled with null bytes. Using result.Count instead of recieveBuffer.Count fixes this problem.