### PR TITLE
(NOT_READY_TO_MERGE) sample for RenderTreeBuilder, #249.  

### DIFF
--- a/projects/blazor-ss/RenderTreeBuilder/ListNames.cs
+++ b/projects/blazor-ss/RenderTreeBuilder/ListNames.cs
@@ -1,0 +1,45 @@
+
+using Microsoft.AspNetCore.Components;
+
+class Separator : ComponentBase
+{
+    protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "hr");
+        builder.CloseElement(); // hr
+    }
+}
+
+class ListNames : ComponentBase
+{
+    protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+    {
+        // see the following:
+        // https://docs.microsoft.com/en-us/aspnet/core/blazor/advanced-scenarios
+
+        builder.OpenElement(0, "ul");
+        var names = new string[]
+        {
+            "Bruce",
+            "Clint",
+            "Donald",
+            "Natasha",
+            "Steve",
+            "Tony",
+        };
+        foreach (var x in names)
+        {
+            builder.OpenElement(1, "li");
+            builder.OpenElement(2, "p");
+            builder.AddContent(3, x);
+            builder.CloseElement(); // p
+            builder.CloseElement(); // li
+        }
+        builder.CloseElement(); // ul
+
+        // shows an example of a nested component
+        builder.OpenComponent<Separator>(4);
+        builder.CloseComponent();
+    }
+}
+

--- a/projects/blazor-ss/RenderTreeBuilder/Program.cs
+++ b/projects/blazor-ss/RenderTreeBuilder/Program.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Html;
+using System.Text.Encodings.Web;
+
+class Program
+{
+    // converts an IHtmlContent to a string
+    static string GetString(IHtmlContent htmlContent)
+    {
+        using (var writer = new StringWriter())
+        {
+            htmlContent.WriteTo(writer, HtmlEncoder.Default);
+            return writer.ToString();
+        }
+    }
+
+    public static void Main(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddMvc(); // for IHtmlHelper
+        builder.Services.AddServerSideBlazor();
+
+        var app = builder.Build();
+
+        app.UseStaticFiles();
+        app.MapBlazorHub();
+
+        app.MapGet("/", 
+            async (HttpContext ctx) =>
+            {
+                ctx.Response.ContentType = "text/html";
+
+                var htmlHelper = ctx.RequestServices.GetRequiredService<IHtmlHelper>();
+                ((IViewContextAware) htmlHelper).Contextualize(new ViewContext{HttpContext = ctx});
+
+                // all of this could be done with a Razor Page,
+                // but this sample uses C# instead
+
+                await ctx.Response.WriteAsync("<html lang=\"en\">");
+
+                await ctx.Response.WriteAsync("<head>");
+                await ctx.Response.WriteAsync("<meta charset=\"utf-8\" />");
+                await ctx.Response.WriteAsync("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />");
+                await ctx.Response.WriteAsync("<base href=\"/\" />");
+                await ctx.Response.WriteAsync("</head>");
+
+                await ctx.Response.WriteAsync("<body>");
+
+                await ctx.Response.WriteAsync("<div>");
+                {
+                    var htmlContent = await htmlHelper.RenderComponentAsync<ListNames>(RenderMode.Server);
+                    await ctx.Response.WriteAsync(GetString(htmlContent));
+                }
+                await ctx.Response.WriteAsync("</div>");
+
+                await ctx.Response.WriteAsync("<script src=\"_framework/blazor.server.js\"></script>");
+
+                await ctx.Response.WriteAsync("</body>");
+                await ctx.Response.WriteAsync("</html>");
+            }
+            );
+
+        app.Run();
+    }
+}
+

--- a/projects/blazor-ss/RenderTreeBuilder/README.md
+++ b/projects/blazor-ss/RenderTreeBuilder/README.md
@@ -1,0 +1,6 @@
+# RenderTreeBuilder
+
+`RenderTreeBuilder` shows a Blazor (server) component implemented without Razor syntax, inheriting from the abstract class `ComponentBase` and implementing the `BuildRenderTree` method. 
+
+Contribution by [ericsink](https://github.com/ericsink).
+

--- a/projects/blazor-ss/RenderTreeBuilder/RenderTreeBuilder.csproj
+++ b/projects/blazor-ss/RenderTreeBuilder/RenderTreeBuilder.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/projects/blazor-ss/RenderTreeBuilder/appsettings.Development.json
+++ b/projects/blazor-ss/RenderTreeBuilder/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/projects/blazor-ss/RenderTreeBuilder/appsettings.json
+++ b/projects/blazor-ss/RenderTreeBuilder/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/projects/blazor-ss/RenderTreeBuilder/global.json
+++ b/projects/blazor-ss/RenderTreeBuilder/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.100-rc.1.21458.32",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
NOTE: currently includes its own global.json to make it build with net6.0 (rc1 on Linux).  probably shouldn't merge into the main repo until it converts to net6.0 as its default.  I tried putting this into the net6 area, but the global.json there appears to be Windows-specific.