### PR TITLE
Net6.0 Caching example 4 - counter is not matching the amount of page refreshes

### DIFF
--- a/projects/caching/caching-4/Program.cs
+++ b/projects/caching/caching-4/Program.cs
@@ -23,6 +23,8 @@ int resetCount = 8;
 
 app.Run(async context =>
 {
+    if (context.Request.Path == "/favicon.ico") return;//skip favicon request
+
     var log = context.RequestServices.GetService<ILoggerFactory>().CreateLogger("app");
     var cache = context.RequestServices.GetService<IMemoryCache>();
     var greeting = cache.Get(CACHE_KEY) as string;


### PR DESCRIPTION
When refreshing the page in the browser 2 requests are made. One for the favicon and one with path "/".
Skip the favicon request to have the counter match the amount of refreshes.
Also, because it now skips over the 8th refresh, the message "Cache expired" is never displayed.


Multiple ways to fix this, but this would be the simplest one i guess. 
Another option is to create a middleware that can be reused whenever this problem occurs in other examples.